### PR TITLE
fix: prevent fork PRs from triggering release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   build:
     name: Build
-    if: ${{ github.event.pull_request.merged }}
+    if: ${{ github.event.pull_request.merged && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Add same-repo check to release pipeline: merged PRs from forks no longer trigger publishing (prevents a crafted version bump from a fork from pushing a package)

## Test plan
- [ ] Verify release still triggers on merged PR from willfarrell/ajv-ftl-i18n with package.json changes
- [ ] Verify release does NOT trigger on merged fork PR